### PR TITLE
Dc strato

### DIFF
--- a/lyrics.lua
+++ b/lyrics.lua
@@ -425,8 +425,9 @@ function prepare_lyrics(name)
 		end		
 		local newcount_index = line:find("#R:")
 		if newcount_index ~= nil then
-			local newcount_indexStart,newcount_indexEnd = line:find("%d",newcount_index+3)		
+			local newcount_indexStart,newcount_indexEnd = line:find("%d+",newcount_index+3)		
 			new_lines = tonumber(line:sub(newcount_indexStart,newcount_indexEnd))
+			_, newcount_indexEnd = line:find("%s+",newcount_indexEnd+1)
 			line = line:sub(newcount_indexEnd + 1)	
 		end			
 		local newcount_index = line:find("#P:")

--- a/lyrics.lua
+++ b/lyrics.lua
@@ -454,9 +454,10 @@ function prepare_lyrics(name)
 				else
 					lyrics[#lyrics] = lyrics[#lyrics] .. "\n" .. line
 				end
-				cur_line = cur_line + 1
 				if single_line or cur_line > adjusted_display_lines then
 					cur_line = 1
+				else
+					cur_line = cur_line + 1
 				end
 				new_lines = new_lines - 1
 			end


### PR DESCRIPTION
Added a flag to possibly prevent timer callback recursion.  Not sure if OBS handles this.  Tried digging through OBS source but didn't see it.  If the callback takes longer than the 100ms then it could hangup OBS.   I think this may have happened a few times when the source function has to load lyrics from a file.  There is an OBS lockup but no crash report and a scene with a load lyrics was the last accessed according to the log.  Testing showed repeated loading of Lyric A scene then Lyric B scene would eventually cause this.  After the recursion lockout I have not been able to repeat the lockup.  Testing will continue as always.

More code added selfishly for my own tech team managing lyrics.  This Sunday had some strange verse options the following helped clean up.

Added ##B in addition to ##P (tech team kept wanting to use B for Blank Line and I had to agree)
Added #B:n and #P:n to repeat a blank line n times
Added #R:n_text_ where the #R:n preceding text, repeats the text n times (saves some space with repetitive verses)

Optimized the  "prepare_lyrics"  function to better manage ###  and coded blanks and repeats.