### PR TITLE
Feature/mac compatibility

### DIFF
--- a/lyrics.lua
+++ b/lyrics.lua
@@ -738,7 +738,7 @@ function update_lyrics_display()
 		alttext = mon_altext
 	end	
 	if link_text then
-		if string.len(text) == 0 and string.len(alttext) == 0 then
+		if (text == nil or string.len(text) == 0) and (alttext == nil or string.len(alttext) == 0) then
 			static = ""
 			title = ""
 		end

--- a/lyrics.lua
+++ b/lyrics.lua
@@ -1286,8 +1286,9 @@ end
 
 -- returns path of the given song name
 function get_song_file_path(name, suffix)
+	local sep = package.config:sub(1,1)
 	if name == nil then return nil end
-    return get_songs_folder_path() .. "\\" .. name .. suffix
+    return get_songs_folder_path() .. sep .. name .. suffix
 end
 
 -- returns path of the lyrics songs folder


### PR DESCRIPTION
Not a lot of major things, but `xdg-open` doesn't work on macOS so I added detection for the platform to fix that and make those functions work. Also found a place where a platform-specific separator broke functionality on linux and mac and one other spot which honestly shouldn't need a check, but somehow it did. I was too lazy to track down exactly why since this easy fix fixes it =]