### PR TITLE
GeNTooGeek patch change visibility before after update source text

### DIFF
--- a/lyrics+.lua
+++ b/lyrics+.lua
@@ -1404,8 +1404,9 @@ function transition_lyric_text(force_show)
         dbg_custom("Instant On")
         -- if text fade is not enabled, then we can cancel the all_sources_fade
         all_sources_fade = false
-        set_text_visibility(TEXT_VISIBLE) -- does update_source_text()
+        set_text_visibility(TEXT_HIDDEN) -- does update_source_text()
         update_source_text()
+	set_text_visibility(TEXT_VISIBLE)
         dbg_inner("no text fade")
     else -- initiate fade out/in
         dbg_custom("Transition Timer")


### PR DESCRIPTION
Small modification to hide sources prior to update and then set to visible again afterward.

As I was playing around with the fading functionality, I noticed that the fading was not consistently timed.  So I started looking into the code, and I began to wonder why the fading is implemented directly in the script, as opposed to relying on the transitions available during source visibility changes.  I noticed that the existing code, when fading is not enabled, simply changes the text while the sources are visible.  By hiding the sources prior to changing the text and then unhiding them after, we can take advantage of the show/hide transitions.

This does do some weird things when Transition Preview to program is enabled and I haven't really worked those out.  My current project doesn't require that option and I won't have time to further troubleshoot until after it is completed, but I will look more into it.  It will likely be a couple weeks before I can dedicate much time to this, again.